### PR TITLE
feat(utils): add helper functions for token validation and info retrieval

### DIFF
--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -1,0 +1,31 @@
+use super::types::Token;
+
+// Define a constant array of supported tokens
+const SUPPORTED_TOKENS: Array<Token> = Array::<Token>::from([
+    Token { name: 'TokenA', symbol: 'TKA', decimals: 18_u8 },
+    Token { name: 'TokenB', symbol: 'TKB', decimals: 18_u8 },
+]);
+
+// Checks if a token symbol is supported
+fn is_supported_token(symbol: felt252) -> bool {
+    let mut i = 0;
+    while i < SUPPORTED_TOKENS.len() {
+        if SUPPORTED_TOKENS[i].symbol == symbol {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+// Retrieves token info for a given symbol
+fn get_token_info(symbol: felt252) -> Option<Token> {
+    let mut i = 0;
+    while i < SUPPORTED_TOKENS.len() {
+        if SUPPORTED_TOKENS[i].symbol == symbol {
+            return Option::Some(SUPPORTED_TOKENS[i]);
+        }
+        i += 1;
+    }
+    Option::None
+}

--- a/src/utils_test.cairo
+++ b/src/utils_test.cairo
@@ -1,0 +1,36 @@
+use super::utils::{is_supported_token, get_token_info};
+use super::types::Token;
+
+#[test]
+fn test_is_supported_token_valid() {
+    // TokenA and TokenB are supported
+    assert(is_supported_token('TKA'));
+    assert(is_supported_token('TKB'));
+}
+
+#[test]
+fn test_is_supported_token_invalid() {
+    // TokenC is not supported
+    assert(!is_supported_token('TKC'));
+}
+
+#[test]
+fn test_get_token_info_valid() {
+    let token = get_token_info('TKA');
+    match token {
+        Option::Some(t) => {
+            assert(t.symbol == 'TKA');
+            assert(t.decimals == 18_u8);
+        },
+        Option::None => panic('Token not found'),
+    }
+}
+
+#[test]
+fn test_get_token_info_invalid() {
+    let token = get_token_info('TKC');
+    match token {
+        Option::Some(_) => panic('Should not find unsupported token'),
+        Option::None => (),
+    }
+}


### PR DESCRIPTION


### Summary

This PR adds utility functions to manage and validate supported tokens in the contract:

- `is_supported_token(symbol: felt252) -> bool`: Checks if a token symbol is in the supported token list.
- `get_token_info(symbol: felt252) -> Option<Token>`: Retrieves token details for a given symbol, or returns None if not found.
- Supported tokens are managed using a constant array of `Token` structs.

### Motivation

These helpers centralize token validation and information retrieval, improving code maintainability and reducing duplication.

### Testing

- Unit tests should be added to verify both valid and invalid token scenarios for these helpers.

---

